### PR TITLE
Fix the position variation of the omnifunc.

### DIFF
--- a/lib/nvim_rplugin.ex
+++ b/lib/nvim_rplugin.ex
@@ -84,7 +84,7 @@ defmodule MixAndComplete do
     {:ok,nil,%{state| current_bindings: bindings}}
   end
 
-  deffunc elixir_complete("1",_,cursor,line,state), eval: "col('.')", eval: "getline('.')" do
+  deffunc elixir_complete(1,_,cursor,line,state), eval: "col('.')", eval: "getline('.')" do
     cursor = cursor - 1 # because we are in insert mode
     [tomatch] = Regex.run(~r"[\w\.:]*$",String.slice(line,0..cursor-1))
     cursor - String.length(tomatch)


### PR DESCRIPTION
omnifunc(1, "") and omnifunc(_, "text") are the usual invocations. We were catching "1" as a string
instead of an int, which broke vim in some cases (omnifunc(1, "") was invoking the incorrect function
variation.
